### PR TITLE
Specific exception message for unfound button names

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ champs d'un rapport existant et de données en YAML.
 python fill_expense_report.py -p rapport_depenses_base.pdf -y field_setting/partial_field_setting.yml -o succès.pdf
 ```
 
+Dans ce dernier cas, on obtient le même résultat si on remplace `-p` par `-t`.
+
 ### Fichiers de données
 
 Le dossier `field_setting` contient des exemples de fichier de données en YAML.

--- a/fill_expense_report.py
+++ b/fill_expense_report.py
@@ -148,8 +148,8 @@ if __name__ == "__main__":
 
 	if template_path == _DFLT_TEMPLATE_PATH:
 		if not template_path.exists():
-			print("ERROR! Default report template '"
-				+ str(template_path) + "' not found.")
+			print("ERROR! Default report template "
+				+ str(template_path) + " not found.")
 			exit(1)
 	else:
 		check_ungenerable_path(

--- a/pdf_field_values.py
+++ b/pdf_field_values.py
@@ -41,14 +41,23 @@ class PdfField:
 
 	@property
 	def name(self):
+		"""
+		str: the name of this PDF field
+		"""
 		return self._name
 
 	@property
 	def type(self):
+		"""
+		str: the type of this PDF field
+		"""
 		return self._type
 
 	@property
 	def value(self):
+		"""
+		any: the value stored in this PDF field
+		"""
 		return self._value
 
 

--- a/pypdf2_util.py
+++ b/pypdf2_util.py
@@ -88,7 +88,12 @@ class RadioBtnGroup:
 		Raises:
 			ValueError: if btn_name is not found
 		"""
-		return self._btn_names.index(btn_name)
+		try:
+			return self._btn_names.index(btn_name)
+
+		except ValueError:
+			raise ValueError("Radio button group " + self._name
+				+ " does not have button " + btn_name + ".")
 
 	def __iter__(self):
 		return iter(self._btn_names)

--- a/pypdf2_util.py
+++ b/pypdf2_util.py
@@ -94,7 +94,7 @@ class RadioBtnGroup:
 			return self._btn_names.index(btn_name)
 
 		except ValueError:
-			# Sometimes, btn_name is None.
+			# btn_name can unknowingly be set to None.
 			raise ValueError("Radio button group " + self._name
 				+ " does not have button " + str(btn_name) + ".")
 

--- a/pypdf2_util.py
+++ b/pypdf2_util.py
@@ -92,8 +92,9 @@ class RadioBtnGroup:
 			return self._btn_names.index(btn_name)
 
 		except ValueError:
+			# Sometimes, btn_name is None.
 			raise ValueError("Radio button group " + self._name
-				+ " does not have button " + btn_name + ".")
+				+ " does not have button " + str(btn_name) + ".")
 
 	def __iter__(self):
 		return iter(self._btn_names)

--- a/pypdf2_util.py
+++ b/pypdf2_util.py
@@ -42,7 +42,9 @@ class RadioBtnGroup:
 		names. At least one button name must be provided.
 
 		Args:
-			group_name (str): the name of this radio button group
+			group_name (str): the name of this radio button group. It should be
+				the name of the field that corresponds to the group in the PDF
+				file.
 			*btn_names: the names of the buttons in this group, as strings. At
 				least one must be provided.
 
@@ -105,8 +107,7 @@ class RadioBtnGroup:
 	@property
 	def name(self):
 		"""
-		The name of this radio button group. It should be the name of the
-		field that corresponds to the group in the PDF file.
+		str: the name of this radio button group
 		"""
 		return self._name
 


### PR DESCRIPTION
An exception with a specific message is raised when RadioBtnGroup.index does not find a button name's index. Some improvements were made in the docstrings and the README.