### PR TITLE
Specific exception message for indices out of bounds

### DIFF
--- a/pypdf2_util.py
+++ b/pypdf2_util.py
@@ -58,7 +58,12 @@ class RadioBtnGroup:
 		self._btn_names = btn_names
 
 	def __getitem__(self, index):
-		return self._btn_names[index]
+		try:
+			return self._btn_names[index]
+
+		except IndexError:
+			raise IndexError("Radio button group " + self._name
+				+ " does not have index " + str(index) + ".")
 
 	def has_index(self, index):
 		"""

--- a/pypdf2_util.py
+++ b/pypdf2_util.py
@@ -311,11 +311,6 @@ def update_page_fields(page, fields, *radio_btn_groups):
 					button_group = btn_group_dict.get(annot_parent_name)
 
 					if button_group is not None:
-						if not button_group.has_index(button_index):
-							raise IndexError(annot_parent_name
-								+ " does not have index "
-								+ str(button_index) + ".")
-
 						button_name = button_group[button_index]
 
 						annot_parent[NameObject(_KEY_KIDS)].getObject()\


### PR DESCRIPTION
RadioBtnGroup.\_\_getitem\_\_ generates an exception message specific to its class. This allowed to remove a verification from function update_page_fields.